### PR TITLE
Allow macros to have multiline strings interpolated correctly

### DIFF
--- a/jenkins_jobs/registry.py
+++ b/jenkins_jobs/registry.py
@@ -22,7 +22,7 @@ import re
 import yaml
 
 from jenkins_jobs.errors import JenkinsJobsException
-from jenkins_jobs.formatter import CustomFormatter
+from jenkins_jobs.formatter import deep_format
 
 logger = logging.getLogger(__name__)
 
@@ -152,16 +152,15 @@ class ModuleRegistry(object):
             if template_data:
                 # Template data contains values that should be interpolated
                 # into the component definition
-                s = yaml.dump(component_data, default_flow_style=False)
                 allow_empty_variables = self.global_config \
                     and self.global_config.has_section('job_builder') \
                     and self.global_config.has_option(
                         'job_builder', 'allow_empty_variables') \
                     and self.global_config.getboolean(
                         'job_builder', 'allow_empty_variables')
-                s = CustomFormatter(
-                    allow_empty_variables).format(s, **template_data)
-                component_data = yaml.load(s)
+
+                component_data = deep_format(
+                    component_data, template_data, allow_empty_variables)
         else:
             # The component is a simple string name, eg "run-tests"
             name = component


### PR DESCRIPTION
I'm not sure if this is the best way to request, track, and discuss this change, but here we go!

Multiline strings passed into macros are apparently a thing upstream doesn't do. It has a number of issues, which as far as I can tell stem from interpolating the variables by dumping the data structure into a yaml string, interpolating the strings and then trying to deserialize that yaml back into python.

This replaces that process (which seems to be how variable interpolation used to be done) with a newer method that is used in other areas variables are interpolated, decreasing the ways in which variables are interpolated.

This also may solve: https://bugs.launchpad.net/openstack-ci/+bug/1387060 but further investigation is necessary.

This passes `tox -e py27` tests locally. And if this looks good to others I'll work writing additional tests and submitting the patch upstream.
